### PR TITLE
Correct NK_MEMCOPY optional define to NK_MEMCPY

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -160,7 +160,7 @@ OPTIONAL DEFINES:
         replacement. If not nuklear will use its own version.
         <!> If used it is only required to be defined for the implementation part <!>
 
-    NK_MEMCOPY
+    NK_MEMCPY
         You can define this to 'memcpy' or your own memcpy implementation
         replacement. If not nuklear will use its own version.
         <!> If used it is only required to be defined for the implementation part <!>


### PR DESCRIPTION
The documentation lists NK_MEMCOPY as the optional macro to be defined to provide a custom 'memcpy', but the rest of the file uses NK_MEMCPY.
